### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,10 @@ name: release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/umatare5/twelvedata-exporter/security/code-scanning/1](https://github.com/umatare5/twelvedata-exporter/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided steps, the workflow interacts with repository contents (e.g., checking out code) and uses the GitHub Container Registry. Therefore, we will set `contents: read` and `packages: write` permissions. These permissions are sufficient for the tasks performed in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
